### PR TITLE
completed admin aprroving and unapproving posts.

### DIFF
--- a/Controllers/PostsController.cs
+++ b/Controllers/PostsController.cs
@@ -30,6 +30,18 @@ public class PostController : ControllerBase
         .OrderBy(p => p.PublishDateTime)
         .ToList());
     }
+    [HttpGet("admin")]
+    [Authorize(Roles = "Admin")]
+    public IActionResult GetAllPosts()
+    {
+        return Ok(_dbContext.Posts
+        .Include(p => p.Category)
+        .Include(p => p.UserProfile)
+        .Include(p => p.PostTags)
+        .ThenInclude(pt => pt.Tag)
+        .OrderBy(p => p.PublishDateTime)
+        .ToList());
+    }
 
 
     [HttpGet("{id}")]
@@ -176,6 +188,30 @@ public class PostController : ControllerBase
         }
 
         _dbContext.Remove(PostToDelete);
+        _dbContext.SaveChanges();
+
+        return NoContent();
+    }
+
+    [HttpPost("approve/{id}")]
+    [Authorize(Roles = "Admin")]
+    public IActionResult ApprovePost(int id)
+    {
+        Post foundPost = _dbContext.Posts.SingleOrDefault(p => p.Id == id);
+        foundPost.IsApproved = true;
+        foundPost.PublishDateTime = DateTime.Now;
+        _dbContext.SaveChanges();
+
+        return NoContent();
+    }
+    
+    [HttpPost("unapprove/{id}")]
+    [Authorize(Roles = "Admin")]
+    public IActionResult UnapprovePost(int id)
+    {
+        Post foundPost = _dbContext.Posts.SingleOrDefault(p => p.Id == id);
+        foundPost.IsApproved = false;
+        foundPost.PublishDateTime = null;
         _dbContext.SaveChanges();
 
         return NoContent();

--- a/client/src/components/ApplicationViews.js
+++ b/client/src/components/ApplicationViews.js
@@ -54,7 +54,7 @@ export default function ApplicationViews({ loggedInUser, setLoggedInUser }) {
             index
             element={
               <AuthorizedRoute loggedInUser={loggedInUser}>
-                <PostsAll />
+                <PostsAll loggedInUser={loggedInUser}/>
               </AuthorizedRoute>
             }
           />

--- a/client/src/components/posts/PostsAll.js
+++ b/client/src/components/posts/PostsAll.js
@@ -1,15 +1,47 @@
 import { useEffect, useState } from 'react';
-import { fetchAllPosts } from '../../managers/postManager.js';
+import { approvePost, fetchAllPosts, fetchAllPostsForAdmin, unapprovePost } from '../../managers/postManager.js';
 import { Button, Table } from 'reactstrap';
 import { useNavigate } from 'react-router-dom';
 
-export const PostsAll = () => {
+export const PostsAll = ({ loggedInUser }) => {
   const [posts, setPosts] = useState();
   const navigate = useNavigate()
 
   const getAllPosts = () => {
-    fetchAllPosts().then(setPosts);
+    if (loggedInUser?.roles?.includes("Admin"))
+    {
+      fetchAllPostsForAdmin().then(setPosts)
+    }
+    else {
+      fetchAllPosts().then(setPosts);
+    }
   };
+
+  const handleApprove = (e, postId) => {
+    e.preventDefault();
+
+    approvePost(postId)
+      .then(() => getAllPosts())
+  }
+  
+  const handleUnapprove = (e, postId) => {
+    e.preventDefault();
+
+    unapprovePost(postId)
+      .then(() => getAllPosts())
+  }
+
+  const showApprovalStatus = (post) => {
+    if (post.isApproved === true) {
+      return <td>
+        <Button color='danger' onClick={(e) => handleUnapprove(e, post.id)}> Unapprove Post</Button>
+        </td>
+    } else {
+      return <td>
+      <Button color='primary' onClick={(e) => handleApprove(e, post.id)}> Approve Post</Button>
+      </td>
+    }
+  }
 
   useEffect(() => {
     getAllPosts();
@@ -39,6 +71,11 @@ export const PostsAll = () => {
                 <td>
                   <Button onClick={() => navigate(`${[p.id]}`)}>View Post</Button>
                 </td>
+                {
+                  loggedInUser?.roles?.includes("Admin") 
+                  ? showApprovalStatus(p) 
+                  :<></>
+                }
               </tr>
             ))}
           </tbody>

--- a/client/src/managers/postManager.js
+++ b/client/src/managers/postManager.js
@@ -4,6 +4,10 @@ export const fetchAllPosts = () => {
   return fetch(_apiUrl).then((res) => res.json());
 };
 
+export const fetchAllPostsForAdmin = () => {
+  return fetch(_apiUrl + "/admin").then((res) => res.json());
+};
+
 export const fetchSinglePost = (id, loggedInUserId) => {
   return fetch(`${_apiUrl}/${id}?userId=${loggedInUserId}`).then((res) =>
     res.json()
@@ -35,3 +39,15 @@ export const deletePost = (id) => {
       method: "DELETE"
   })
 };
+
+export const approvePost = (id) => {
+  return fetch(`${_apiUrl}/approve/${id}`, {
+    method: "POST"
+  })
+}
+
+export const unapprovePost = (id) => {
+  return fetch(`${_apiUrl}/unapprove/${id}`, {
+    method: "POST"
+  })
+}


### PR DESCRIPTION
 Added functionality for this that only logged in admins can view that either approves and publishes a post or unapproves and unpublishes a post. Created a new endpoint for post list for admins so they can see both types of post simultaneously, but regular users can only see approved and published posts. closes #40 closes #41